### PR TITLE
Added allow and blacklist commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,5 +142,6 @@ dmypy.json
 # Built Visual Studio Code Extensions
 *.vsix
 
-# logs
+# data
 data/feurlog.csv
+data/channelBlacklist.csv

--- a/bot.py
+++ b/bot.py
@@ -57,11 +57,10 @@ async def on_message(message: discord.Message):
         await message.delete()
         await message.channel.send(link_fixer.handle_message(message))
 
-    blacklist = filter._get_blacklist()
-    channel_id = message.channel.id
+    blacklist = filter.get_blacklist()
 
     # The one and only necessary feature
-    if "quoi" in message.content.lower() and channel_id not in blacklist:
+    if "quoi" in message.content.lower() and message.channel.id not in blacklist:
         feur_controller = feur.FeurController(message)
         answer, sticker = feur_controller.create_feur_answer()
         if answer or sticker:  # Depending on our luck, we don't answer "feur" but use a sticker instead

--- a/config/config.json
+++ b/config/config.json
@@ -41,6 +41,7 @@
         }
     },
     "channel_filter":{
+        "separator":",",
         "channel_csv_filepath":"data/channelBlacklist.csv"
     }
 }

--- a/config/config.json
+++ b/config/config.json
@@ -39,5 +39,8 @@
             "match": "https:\/\/(twitter.com|x.com)(\/[a-zA-Z0-9_]{5,15}\/status\/[0-9]{0,20})",
             "replacement": "vxtwitter.com"
         }
+    },
+    "channel_filter":{
+        "channel_csv_filepath":"data/channelBlacklist.csv"
     }
 }

--- a/data/channelBlacklist.csv
+++ b/data/channelBlacklist.csv
@@ -1,0 +1,1 @@
+channel_id

--- a/features/channelFilter.py
+++ b/features/channelFilter.py
@@ -51,7 +51,7 @@ class Filter:
         else :
             return "channel already allowed"
 
-    def _get_blacklist(self):
+    def get_blacklist(self):
         # Extracting data from the csv in a DataFrame object
         file_content = pd.read_csv(self.csv_filepath)
 

--- a/features/channelFilter.py
+++ b/features/channelFilter.py
@@ -1,0 +1,59 @@
+import pandas as pd
+import json
+import discord
+from features import logging
+
+class Filter:
+
+    def __init__(self) -> None:
+        with open("config/config.json") as config_file:
+            self.config = json.load(config_file)["channel_filter"]
+            self.csv_filepath = self.config["channel_csv_filepath"]
+
+    def add_channel_to_ignore_list(self, channel:str) -> str:
+
+        # Extracting data from the csv in a DataFrame object
+        file_content = pd.read_csv(self.csv_filepath)
+
+        # Extracts the channel ids from the csv
+        channel_list = logging.Logger()._get_column_data_from_file(file_content, 'channel_id')
+
+        if channel not in channel_list:
+
+            # Adding a new row to the file
+            new_channel = pd.DataFrame({'channel_id': [channel]})
+            file_content = pd.concat([file_content, new_channel])
+
+            # After updating the DataFrame, we save the changes in the csv file
+            file_content.to_csv(self.csv_filepath, index=False)
+            return "succesfully blacklisted channel"
+        
+        else :
+            return "channel already blacklisted"
+
+    def remove_channel_from_ignore_list(self, channel:str) -> str:
+
+        # Extracting data from the csv in a DataFrame object
+        file_content = pd.read_csv(self.csv_filepath)
+
+        # Extracts the channel ids from the csv
+        channel_list = logging.Logger()._get_column_data_from_file(file_content, 'channel_id')
+
+        if channel in channel_list:
+            
+            # Remove row from the file
+            file_content = file_content[file_content.channel_id != channel]
+
+            # After updating the DataFrame, we save the changes in the csv file
+            file_content.to_csv(self.csv_filepath, index=False)
+            return "succesfully allowed channel"
+        
+        else :
+            return "channel already allowed"
+
+    def _get_blacklist(self):
+        # Extracting data from the csv in a DataFrame object
+        file_content = pd.read_csv(self.csv_filepath)
+
+        # Extracts the channel ids from the csv
+        return logging.Logger()._get_column_data_from_file(file_content, 'channel_id')


### PR DESCRIPTION
Added a way to prevent the bot from auto-replying in certain channels (for example channels dedicated to more serious topics)
- /blacklist prevents the bot from activating its feur in the current channel
- /allow to allow the bot to post in a previously restricted channel