### PR TITLE
Changed frequency of stickers being sent

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,6 +1,6 @@
 {
     "feur_frequency": 0.4,
-    "feur_sticker_frequency": 0.35,
+    "feur_sticker_frequency": 0.01,
     "feur_sticker_path":"ressources/images/FeurAllezHopLa.png",
     "feur_options": [
         "Feur",


### PR DESCRIPTION
The sticker, originally meant to be a rarer response, ended up being the most common one due to the way a message is picked. When a response is triggered, the message had a 35% chance of being a sticker, leaving 65% for the written options. However, even when ignoring the special triggers which lower the appearance rate of prewritten options, with the current amount of options they each end up having around a 7% chance to appear each, making them 4x less likely to appear than the sticker. In addition, on mobile while the keyboard is enabled, the sticker fills the rest of the screen making the message that triggered it to go offscreen forcing the user to scroll or close the keyboard to read the message, which, although it doesn't take a lot of effort, is mildly inconvenient and rarifying the sticker would make such an inconvenience less likely to happen.